### PR TITLE
Changed row additions to use same container

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,7 +8,8 @@ function add_rows() {
   // there are rows that can be removed
   if (document.getElementsByTagName("tr").length > 0) {
     let rows = document.getElementsByTagName("tr");
-    grid.appendChild(rows[0].cloneNode(true));
+    let clone = rows[0].cloneNode(true);
+    grid.children[0].appendChild(clone);
   } else {
     // there are no existing rows
     let newRow = document.createElement("tr");


### PR DESCRIPTION
Rows were being added outside of `tbody`. Now, they're all in the same container. Fixes #24.